### PR TITLE
fix missing cdc on ante handler options

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -791,6 +791,7 @@ func NewUptick(
 
 	maxGasWanted := cast.ToUint64(appOpts.Get(srvflags.EVMMaxTxGasWanted))
 	options := ante.HandlerOptions{
+		Cdc:             app.appCodec,
 		AccountKeeper:   app.AccountKeeper,
 		BankKeeper:      app.BankKeeper,
 		IBCKeeper:       app.IBCKeeper,


### PR DESCRIPTION
Fixing error panic when executing authz Msg Exec #18 due to undefined cdc on [validateAuthz](https://github.com/UptickNetwork/uptick/blob/b7ef90210c63737035f8072e084ca5731e0eb14c/app/ante/comission.go#L52)