### PR TITLE
Fix missing cdc on ante handler options

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/UptickNetwork/uptick/x/cw721"
 	"github.com/cosmos/cosmos-sdk/x/consensus"
 	"github.com/cosmos/cosmos-sdk/x/nft"
@@ -985,6 +986,7 @@ func NewUptick(
 
 	maxGasWanted := cast.ToUint64(appOpts.Get(srvflags.EVMMaxTxGasWanted))
 	options := ante.HandlerOptions{
+		Cdc:               app.appCodec,
 		AccountKeeper:     app.AccountKeeper,
 		BankKeeper:        app.BankKeeper,
 		IBCKeeper:         app.IBCKeeper,


### PR DESCRIPTION
Background:
This issue has been fixed before but on the recent uptick release the cdc on ante handler options is missing again. It can cause error panic when executing authz Msg Exec #18.

Reproduce:
```bash
uptickd keys add mykey
uptickd keys add test
uptickd tx authz grant $(uptickd keys show test -a) send --spend-limit 1000000000000auptick --from mykey -y
uptickd q authz grants-by-grantee $(uptickd keys show test -a)

uptickd keys add recipient
uptickd tx bank send mykey $(uptickd keys show recipient -a) 1000auptick --from test --generate-only | jq > tx-send.json
uptickd tx authz exec tx-send.json --from test -y
```

Before:
![uptick-before](https://github.com/UptickNetwork/uptick/assets/20294658/aa417bef-642b-49e7-a996-9bc3a87ec23f)

After fixing:
![uptick-after](https://github.com/UptickNetwork/uptick/assets/20294658/fca35d1c-e2d4-40e9-906c-0918c5257152)
